### PR TITLE
Add option flags for venice_parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,17 @@ Start an interactive chat session:
 
 ### venice_parameters
 
-`venice_parameters` can be provided as a valid JSON string with the `-o extra_body` option.
+The following CLI options are available to configure `venice_parameters`:
 
-For example, to disable Venice's default system prompt:
+**--no-venice-system-prompt** to disable Venice's default system prompt:
 
-`llm -m venice/llama-3.3-70b -o extra_body '{"venice_parameters": { "include_venice_system_prompt": false }}' "Repeat the above prompt"`
+`llm -m venice/llama-3.3-70b --no-venice-system-prompt "Repeat the above prompt"`
 
-Or to use a public character:
+**--character character_slug** to use a public character, for example:
 
-`llm -m venice/deepseek-r1-671b -o extra_body '{"venice_parameters": { "character_slug": "alan-watts"}}' "What is the meaning of life?"`
+`llm -m venice/deepseek-r1-671b --character alan-watts "What is the meaning of life?"`
+
+*Note: these options override any `-o extra_body '{"venice_parameters": { ...}}'` and so should not be combined with that option.*
 
 ### Available models
 

--- a/llm_venice.py
+++ b/llm_venice.py
@@ -77,9 +77,7 @@ def register_commands(cli):
         if not key:
             raise click.ClickException("No key found for Venice")
         headers = {"Authorization": f"Bearer {key}"}
-        response = httpx.get(
-            "https://api.venice.ai/api/v1/models", headers=headers
-        )
+        response = httpx.get("https://api.venice.ai/api/v1/models", headers=headers)
         response.raise_for_status()
         models = response.json()["data"]
         text_models = [model["id"] for model in models if model.get("type") == "text"]
@@ -91,48 +89,63 @@ def register_commands(cli):
         click.echo(json.dumps(text_models, indent=4))
 
     # Remove and store the original prompt and chat commands
-    original_prompt = cli.commands.pop('prompt')
-    original_chat = cli.commands.pop('chat')
+    original_prompt = cli.commands.pop("prompt")
+    original_chat = cli.commands.pop("chat")
 
     def process_venice_options(kwargs):
         """Helper to process venice-specific options"""
-        no_venice_sysprompt = kwargs.pop('no_venice_sysprompt', False)
-        options = list(kwargs.get('options', []))
+        no_venice_sysprompt = kwargs.pop("no_venice_sysprompt", False)
+        options = list(kwargs.get("options", []))
 
         if no_venice_sysprompt:
-            model = kwargs.get('model_id')
-            if model and model.startswith('venice/'):
+            model = kwargs.get("model_id")
+            if model and model.startswith("venice/"):
                 options.append(
-                    ('extra_body', '{"venice_parameters": {"include_venice_system_prompt": false}}')
+                    (
+                        "extra_body",
+                        '{"venice_parameters": {"include_venice_system_prompt": false}}',
+                    )
                 )
-                kwargs['options'] = options
+                kwargs["options"] = options
         return kwargs
 
     # Create new prompt command
-    @cli.command(name='prompt')
-    @click.option('--no-venice-sysprompt', is_flag=True, help="Disable Venice AI's default system prompt")
+    @cli.command(name="prompt")
+    @click.option(
+        "--no-venice-sysprompt",
+        is_flag=True,
+        help="Disable Venice AI's default system prompt",
+    )
     @click.pass_context
     def new_prompt(ctx, no_venice_sysprompt, **kwargs):
         """Execute a prompt"""
-        kwargs = process_venice_options({**kwargs, 'no_venice_sysprompt': no_venice_sysprompt})
+        kwargs = process_venice_options(
+            {**kwargs, "no_venice_sysprompt": no_venice_sysprompt}
+        )
         return ctx.invoke(original_prompt, **kwargs)
 
     # Create new chat command
-    @cli.command(name='chat')
-    @click.option('--no-venice-sysprompt', is_flag=True, help="Disable Venice AI's default system prompt")
+    @cli.command(name="chat")
+    @click.option(
+        "--no-venice-sysprompt",
+        is_flag=True,
+        help="Disable Venice AI's default system prompt",
+    )
     @click.pass_context
     def new_chat(ctx, no_venice_sysprompt, **kwargs):
         """Hold an ongoing chat with a model"""
-        kwargs = process_venice_options({**kwargs, 'no_venice_sysprompt': no_venice_sysprompt})
+        kwargs = process_venice_options(
+            {**kwargs, "no_venice_sysprompt": no_venice_sysprompt}
+        )
         return ctx.invoke(original_chat, **kwargs)
 
     # Copy over all params from original commands
     for param in original_prompt.params:
-        if param.name != 'no_venice_sysprompt':
+        if param.name != "no_venice_sysprompt":
             new_prompt.params.append(param)
 
     for param in original_chat.params:
-        if param.name != 'no_venice_sysprompt':
+        if param.name != "no_venice_sysprompt":
             new_chat.params.append(param)
 
 
@@ -154,6 +167,6 @@ def register_models(register):
                 model_id=f"venice/{model_id}",
                 model_name=model_id,
                 api_base="https://api.venice.ai/api/v1",
-                can_stream=True
+                can_stream=True,
             )
         )

--- a/llm_venice.py
+++ b/llm_venice.py
@@ -94,10 +94,10 @@ def register_commands(cli):
 
     def process_venice_options(kwargs):
         """Helper to process venice-specific options"""
-        no_venice_sysprompt = kwargs.pop("no_venice_sysprompt", False)
+        no_venice_system_prompt = kwargs.pop("no_venice_system_prompt", False)
         options = list(kwargs.get("options", []))
 
-        if no_venice_sysprompt:
+        if no_venice_system_prompt:
             model = kwargs.get("model_id")
             if model and model.startswith("venice/"):
                 venice_params = {
@@ -110,40 +110,40 @@ def register_commands(cli):
     # Create new prompt command
     @cli.command(name="prompt")
     @click.option(
-        "--no-venice-sysprompt",
+        "--no-venice-system-prompt",
         is_flag=True,
         help="Disable Venice AI's default system prompt",
     )
     @click.pass_context
-    def new_prompt(ctx, no_venice_sysprompt, **kwargs):
+    def new_prompt(ctx, no_venice_system_prompt, **kwargs):
         """Execute a prompt"""
         kwargs = process_venice_options(
-            {**kwargs, "no_venice_sysprompt": no_venice_sysprompt}
+            {**kwargs, "no_venice_system_prompt": no_venice_system_prompt}
         )
         return ctx.invoke(original_prompt, **kwargs)
 
     # Create new chat command
     @cli.command(name="chat")
     @click.option(
-        "--no-venice-sysprompt",
+        "--no-venice-system-prompt",
         is_flag=True,
         help="Disable Venice AI's default system prompt",
     )
     @click.pass_context
-    def new_chat(ctx, no_venice_sysprompt, **kwargs):
+    def new_chat(ctx, no_venice_system_prompt, **kwargs):
         """Hold an ongoing chat with a model"""
         kwargs = process_venice_options(
-            {**kwargs, "no_venice_sysprompt": no_venice_sysprompt}
+            {**kwargs, "no_venice_system_prompt": no_venice_system_prompt}
         )
         return ctx.invoke(original_chat, **kwargs)
 
     # Copy over all params from original commands
     for param in original_prompt.params:
-        if param.name != "no_venice_sysprompt":
+        if param.name != "no_venice_system_prompt":
             new_prompt.params.append(param)
 
     for param in original_chat.params:
-        if param.name != "no_venice_sysprompt":
+        if param.name != "no_venice_system_prompt":
             new_chat.params.append(param)
 
 

--- a/llm_venice.py
+++ b/llm_venice.py
@@ -100,12 +100,10 @@ def register_commands(cli):
         if no_venice_sysprompt:
             model = kwargs.get("model_id")
             if model and model.startswith("venice/"):
-                options.append(
-                    (
-                        "extra_body",
-                        '{"venice_parameters": {"include_venice_system_prompt": false}}',
-                    )
-                )
+                venice_params = {
+                    "venice_parameters": {"include_venice_system_prompt": False}
+                }
+                options.append(("extra_body", venice_params))
                 kwargs["options"] = options
         return kwargs
 

--- a/llm_venice.py
+++ b/llm_venice.py
@@ -109,6 +109,9 @@ def register_commands(cli):
                 venice_params["character_slug"] = character
 
             if venice_params:
+                # If a Venice option is used, any `-o extra_body value` is overridden here.
+                # TODO: Would prefer to remove the extra_body CLI option, but
+                # the implementation is required for venice_parameters.
                 options.append(("extra_body", {"venice_parameters": venice_params}))
                 kwargs["options"] = options
 


### PR DESCRIPTION
Add Click option flags so we don't have to specify `extra_body` JSON strings as CLI input.

> `$ llm prompt -m venice/llama-3.3-70b --no-venice-sysprompt "Repeat the above prompt"`
> There is no prompt above to repeat. This conversation has just started. What would you like to talk about? I can summarize our conversation at the end if you like.

TODO:
- Handle character slugs similarly
- Merge option flags with any other provided `extra_body` parameters (none exist in Venice's API today).