### PR TITLE
Add expiration date option to api-keys create command

### DIFF
--- a/llm_venice.py
+++ b/llm_venice.py
@@ -128,7 +128,8 @@ def register_commands(cli):
     def rate_limits(ctx):
         "Show current rate limits for your API key"
         response = httpx.get(
-            "https://api.venice.ai/api/v1/api_keys/rate_limits", headers=ctx.obj["headers"]
+            "https://api.venice.ai/api/v1/api_keys/rate_limits",
+            headers=ctx.obj["headers"],
         )
         response.raise_for_status()
         click.echo(json.dumps(response.json(), indent=2))

--- a/llm_venice.py
+++ b/llm_venice.py
@@ -142,10 +142,28 @@ def register_commands(cli):
         help="Type of API key",
     )
     @click.option("--description", default="", help="Description for the new API key")
+    @click.option(
+        "--expiration-date",
+        type=click.DateTime(
+            formats=[
+                "%Y-%m-%d",  # 2025-02-19
+                "%Y-%m-%dT%H:%M",  # 2025-02-19T00:00
+                "%Y-%m-%dT%H:%M:%S",  # 2025-02-19T00:00:00
+            ]
+        ),
+        default=None,
+        help="The API Key expiration date",
+    )
     @click.pass_context
-    def create_key(ctx, key_type, description):
+    def create_key(ctx, description, key_type, expiration_date):
         """Create a new API key."""
-        payload = {"description": description, "apiKeyType": key_type}
+        payload = {
+            "description": description,
+            "apiKeyType": key_type,
+            "expiresAt": expiration_date.strftime("%Y-%m-%dT%H:%M:%SZ")
+            if expiration_date
+            else None,
+        }
         response = httpx.post(
             "https://api.venice.ai/api/v1/api_keys",
             headers=ctx.obj["headers"],

--- a/llm_venice.py
+++ b/llm_venice.py
@@ -146,9 +146,9 @@ def register_commands(cli):
         "--expiration-date",
         type=click.DateTime(
             formats=[
-                "%Y-%m-%d",  # 2025-02-19
-                "%Y-%m-%dT%H:%M",  # 2025-02-19T00:00
-                "%Y-%m-%dT%H:%M:%S",  # 2025-02-19T00:00:00
+                "%Y-%m-%d",
+                "%Y-%m-%dT%H:%M",
+                "%Y-%m-%dT%H:%M:%S",
             ]
         ),
         default=None,
@@ -162,7 +162,7 @@ def register_commands(cli):
             "apiKeyType": key_type,
             "expiresAt": expiration_date.strftime("%Y-%m-%dT%H:%M:%SZ")
             if expiration_date
-            else None,
+            else "",
         }
         response = httpx.post(
             "https://api.venice.ai/api/v1/api_keys",


### PR DESCRIPTION
Doesn't work without datestring yet, API doesn't seem to accept the null value.