### PR TITLE
Use compression

### DIFF
--- a/llm_venice.py
+++ b/llm_venice.py
@@ -131,7 +131,11 @@ class VeniceImage(llm.Model):
         }
 
         url = "https://api.venice.ai/api/v1/image/generate"
-        headers = {"Authorization": f"Bearer {key}", "Content-Type": "application/json"}
+        headers = {
+            "Authorization": f"Bearer {key}",
+            "Accept-Encoding": "gzip",
+            "Content-Type": "application/json",
+        }
 
         r = httpx.post(url, headers=headers, json=payload, timeout=120)
 


### PR DESCRIPTION
Seems llm doesn't use Accept-Encoding, probably simpler to leave the Chat as-is.

Implemented for images. Requesting `gzip` works (response includes `"content-encoding": "gzip"` headers), but `br` for brotli does not.

#19