### PR TITLE
Add consumption limits options for API key creation

### DIFF
--- a/llm_venice.py
+++ b/llm_venice.py
@@ -268,8 +268,20 @@ def register_commands(cli):
         default=None,
         help="The API Key expiration date",
     )
+    @click.option(
+        "--limits-vcu",
+        type=click.FloatRange(min=0.0),
+        default=None,
+        help="VCU consumption limit per epoch",
+    )
+    @click.option(
+        "--limits-usd",
+        type=click.FloatRange(min=0.0),
+        default=None,
+        help="USD consumption limit per epoch",
+    )
     @click.pass_context
-    def create_key(ctx, description, key_type, expiration_date):
+    def create_key(ctx, description, key_type, expiration_date, limits_vcu, limits_usd):
         """Create a new API key."""
         payload = {
             "description": description,
@@ -277,6 +289,10 @@ def register_commands(cli):
             "expiresAt": expiration_date.strftime("%Y-%m-%dT%H:%M:%SZ")
             if expiration_date
             else "",
+            "consumptionLimit": {
+                "vcu": limits_vcu if limits_vcu else None,
+                "usd": limits_usd if limits_usd else None,
+            },
         }
         response = httpx.post(
             "https://api.venice.ai/api/v1/api_keys",

--- a/llm_venice.py
+++ b/llm_venice.py
@@ -392,9 +392,7 @@ def register_commands(cli):
         help="Use a Venice AI public character (e.g. 'alan-watts')",
     )
     @click.pass_context
-    def new_prompt(
-        ctx, no_venice_system_prompt, web_search, character, **kwargs
-    ):
+    def new_prompt(ctx, no_venice_system_prompt, web_search, character, **kwargs):
         """Execute a prompt"""
         kwargs = process_venice_options(
             {
@@ -480,9 +478,11 @@ def register_models(register):
                 api_base="https://api.venice.ai/api/v1",
                 can_stream=True,
                 vision=model_configs.get(model_id, {}).get("vision", False),
-                supports_schema=capabilities.get("supportsResponseSchema", False)
+                supports_schema=capabilities.get("supportsResponseSchema", False),
             )
-            model_instance.supports_web_search = capabilities.get("supportsWebSearch", False)
+            model_instance.supports_web_search = capabilities.get(
+                "supportsWebSearch", False
+            )
             register(model_instance)
         elif model.get("type") == "image":
             register(VeniceImage(model_id=model_id, model_name=model_id))

--- a/llm_venice.py
+++ b/llm_venice.py
@@ -290,8 +290,8 @@ def register_commands(cli):
             if expiration_date
             else "",
             "consumptionLimit": {
-                "vcu": limits_vcu if limits_vcu else None,
-                "usd": limits_usd if limits_usd else None,
+                "vcu": limits_vcu,
+                "usd": limits_usd,
             },
         }
         response = httpx.post(


### PR DESCRIPTION
Also fixes bug since `consumptionLimit` is now required for the request.