### PR TITLE
Update to llm 0.33; various test and development changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,38 +1,17 @@
 # Repository Guidelines
 
-## Project Structure & Module Organization
-- `llm_venice/` is the main plugin package.
-  - `llm_venice/api/` contains Venice API clients and helpers.
-  - `llm_venice/models/` contains model wrappers (chat, image, audio).
-  - `llm_venice/cli/` contains CLI command implementations and options.
-- `tests/` holds the pytest suite (unit + integration).
-- `pyproject.toml` defines dependencies and tooling configuration.
-- `README.md` documents end-user usage and examples.
+- Use the existing virtual environment: `source .venv/bin/activate`
+- If there is no venv, create it first with uv: `uv venv`
+- Install llm-venice in editable mode with test and development dependencies: `uv pip install -e '.[test,dev]'`
+- Run the following checks before considering a task completed:
 
-## Build, Test, and Development Commands
-- `uv venv` and `source .venv/bin/activate`: create and activate a local virtualenv.
-- `uv pip install -e '.[test,dev]'`: install the plugin in editable mode with test/dev deps.
-- `uv pip install pre-commit` and `pre-commit install`: enable pre-commit hooks if you use them.
-- `pytest`: run the default test suite (integration tests are excluded by default).
-- After install, a quick smoke check is `llm models --query venice`.
-
-## Coding Style & Naming Conventions
-- Python 3.10+; 4-space indentation; line length 100.
-- Ruff is configured for linting/formatting (see `pyproject.toml`). Use `ruff format .` and `ruff check .` before submitting.
-- Pyright is configured for static type checks (optional but encouraged).
-- Use snake_case for modules/functions, PascalCase for classes, and keep CLI option names consistent with existing commands.
-
-## Testing Guidelines
-- Tests live in `tests/` and follow `test_*.py` naming.
-- Integration tests are marked with `@pytest.mark.integration` and require a Venice API key.
-- Provide `LLM_VENICE_KEY` or `llm keys set venice` before running integration tests.
-- Run integration tests explicitly: `pytest -m integration`.
-
-## Commit & Pull Request Guidelines
-- Recent commit history uses short, imperative subject lines (e.g., "Add ...", "Fix ..."); keep messages concise and scoped.
-- PRs should include a summary, test command(s) run, and any relevant screenshots/logs when behavior changes.
-- Link related issues and update tests or README when you add or change user-facing behavior.
-
-## Configuration & Secrets
-- Store API keys in `LLM_VENICE_KEY` or the llm key store (`llm keys set venice`).
-- Avoid committing credentials; rely on environment variables or local key storage.
+```sh
+# Run the tests:
+pytest
+# Run the formatter:
+ruff format
+# Run the linter:
+ruff check
+# Run static type checks:
+pyright
+```

--- a/llm_venice/api/characters.py
+++ b/llm_venice/api/characters.py
@@ -4,7 +4,7 @@ import json
 import pathlib
 from typing import Optional
 
-import httpx
+import httpx2
 import llm
 
 from llm_venice.api.client import get_auth_headers
@@ -32,14 +32,14 @@ def list_characters(
     headers = get_auth_headers(key)
     params = {k: v for k, v in {"isWebEnabled": web_enabled, "isAdult": adult}.items() if v}
 
-    response = httpx.get(
+    response = httpx2.get(
         ENDPOINT_CHARACTERS,
         headers=headers,
         params=params,
     )
     try:
         response.raise_for_status()
-    except httpx.HTTPStatusError as exc:
+    except httpx2.HTTPStatusError as exc:
         raise_api_error("Listing characters", exc)
     return response.json()
 

--- a/llm_venice/api/errors.py
+++ b/llm_venice/api/errors.py
@@ -2,7 +2,7 @@
 
 from typing import Optional, Tuple
 
-import httpx
+import httpx2
 
 
 class VeniceAPIError(RuntimeError):
@@ -54,8 +54,8 @@ def _format_error_message(
     return message
 
 
-def _extract_error_parts(response: httpx.Response) -> Tuple[Optional[str], Optional[str]]:
-    """Extract a useful error code/detail tuple from an httpx.Response."""
+def _extract_error_parts(response: httpx2.Response) -> Tuple[Optional[str], Optional[str]]:
+    """Extract a useful error code/detail tuple from an httpx2.Response."""
     try:
         payload = response.json()
     except ValueError:
@@ -77,7 +77,7 @@ def _extract_error_parts(response: httpx.Response) -> Tuple[Optional[str], Optio
     return error_code, detail
 
 
-def raise_api_error(action: str, error: httpx.HTTPStatusError):
+def raise_api_error(action: str, error: httpx2.HTTPStatusError):
     """Normalize HTTPStatusError into a VeniceAPIError for callers."""
     response = error.response
     status = response.status_code if response is not None else "unknown status"

--- a/llm_venice/api/keys.py
+++ b/llm_venice/api/keys.py
@@ -2,7 +2,7 @@
 
 from typing import Dict, Optional
 
-import httpx
+import httpx2
 
 from llm_venice.api.errors import raise_api_error
 from llm_venice.constants import (
@@ -22,10 +22,10 @@ def list_api_keys(headers: Dict[str, str]) -> dict:
     Returns:
         JSON response with API keys
     """
-    response = httpx.get(ENDPOINT_API_KEYS, headers=headers)
+    response = httpx2.get(ENDPOINT_API_KEYS, headers=headers)
     try:
         response.raise_for_status()
-    except httpx.HTTPStatusError as exc:
+    except httpx2.HTTPStatusError as exc:
         raise_api_error("Listing API keys", exc)
     return response.json()
 
@@ -40,10 +40,10 @@ def get_rate_limits(headers: Dict[str, str]) -> dict:
     Returns:
         JSON response with rate limits
     """
-    response = httpx.get(ENDPOINT_API_KEYS_RATE_LIMITS, headers=headers)
+    response = httpx2.get(ENDPOINT_API_KEYS_RATE_LIMITS, headers=headers)
     try:
         response.raise_for_status()
-    except httpx.HTTPStatusError as exc:
+    except httpx2.HTTPStatusError as exc:
         raise_api_error("Retrieving rate limits", exc)
     return response.json()
 
@@ -58,10 +58,10 @@ def get_rate_limits_log(headers: Dict[str, str]) -> dict:
     Returns:
         JSON response with rate limit logs
     """
-    response = httpx.get(ENDPOINT_API_KEYS_RATE_LIMITS_LOG, headers=headers)
+    response = httpx2.get(ENDPOINT_API_KEYS_RATE_LIMITS_LOG, headers=headers)
     try:
         response.raise_for_status()
-    except httpx.HTTPStatusError as exc:
+    except httpx2.HTTPStatusError as exc:
         raise_api_error("Retrieving rate limit logs", exc)
     return response.json()
 
@@ -97,10 +97,10 @@ def create_api_key(
             "usd": limits_usd,
         },
     }
-    response = httpx.post(ENDPOINT_API_KEYS, headers=headers, json=payload)
+    response = httpx2.post(ENDPOINT_API_KEYS, headers=headers, json=payload)
     try:
         response.raise_for_status()
-    except httpx.HTTPStatusError as exc:
+    except httpx2.HTTPStatusError as exc:
         raise_api_error("Creating API key", exc)
     return response.json()
 
@@ -117,9 +117,9 @@ def delete_api_key(headers: Dict[str, str], api_key_id: str) -> dict:
         JSON response confirming deletion
     """
     params = {"id": api_key_id}
-    response = httpx.delete(ENDPOINT_API_KEYS, headers=headers, params=params)
+    response = httpx2.delete(ENDPOINT_API_KEYS, headers=headers, params=params)
     try:
         response.raise_for_status()
-    except httpx.HTTPStatusError as exc:
+    except httpx2.HTTPStatusError as exc:
         raise_api_error("Deleting API key", exc)
     return response.json()

--- a/llm_venice/api/refresh.py
+++ b/llm_venice/api/refresh.py
@@ -4,7 +4,7 @@ import json
 from typing import Optional
 import pathlib
 
-import httpx
+import httpx2
 import llm
 
 from llm_venice.constants import ENDPOINT_MODELS
@@ -25,14 +25,14 @@ def fetch_models(key: Optional[str] = None):
     """
     headers = get_auth_headers(key)
 
-    models_response = httpx.get(
+    models_response = httpx2.get(
         ENDPOINT_MODELS,
         headers=headers,
         params={"type": "all"},
     )
     try:
         models_response.raise_for_status()
-    except httpx.HTTPStatusError as exc:
+    except httpx2.HTTPStatusError as exc:
         raise_api_error("Fetching model list", exc)
     models = models_response.json()["data"]
 

--- a/llm_venice/api/upscale.py
+++ b/llm_venice/api/upscale.py
@@ -4,7 +4,7 @@ import pathlib
 from dataclasses import dataclass
 from typing import Optional, Union
 
-import httpx
+import httpx2
 
 from llm_venice.constants import ENDPOINT_IMAGE_UPSCALE
 from llm_venice.api.client import get_auth_headers
@@ -55,10 +55,10 @@ def perform_image_upscale(
     # Remove None values from data in order to use API defaults
     data = {k: v for k, v in data.items() if v is not None}
 
-    r = httpx.post(ENDPOINT_IMAGE_UPSCALE, headers=headers, files=files, data=data, timeout=120)
+    r = httpx2.post(ENDPOINT_IMAGE_UPSCALE, headers=headers, files=files, data=data, timeout=120)
     try:
         r.raise_for_status()
-    except httpx.HTTPStatusError as exc:
+    except httpx2.HTTPStatusError as exc:
         raise_api_error("Upscaling image", exc)
 
     image_bytes = r.content

--- a/llm_venice/cli/api_keys.py
+++ b/llm_venice/cli/api_keys.py
@@ -3,7 +3,7 @@
 import json
 
 import click
-import httpx
+import httpx2
 
 from llm_venice.api import keys as api_keys
 from llm_venice.api.errors import VeniceAPIError
@@ -37,7 +37,7 @@ def create_api_keys_group():
         """List all API keys."""
         try:
             response = api_keys.list_api_keys(ctx.obj["headers"])
-        except (VeniceAPIError, httpx.RequestError) as e:
+        except (VeniceAPIError, httpx2.RequestError) as e:
             handle_cli_error(e)
         else:
             click.echo(json.dumps(response, indent=2))
@@ -48,7 +48,7 @@ def create_api_keys_group():
         """Show current rate limits for your API key"""
         try:
             response = api_keys.get_rate_limits(ctx.obj["headers"])
-        except (VeniceAPIError, httpx.RequestError) as e:
+        except (VeniceAPIError, httpx2.RequestError) as e:
             handle_cli_error(e)
         else:
             click.echo(json.dumps(response, indent=2))
@@ -59,7 +59,7 @@ def create_api_keys_group():
         """Show the last 50 rate limit logs for the account"""
         try:
             response = api_keys.get_rate_limits_log(ctx.obj["headers"])
-        except (VeniceAPIError, httpx.RequestError) as e:
+        except (VeniceAPIError, httpx2.RequestError) as e:
             handle_cli_error(e)
         else:
             click.echo(json.dumps(response, indent=2))
@@ -110,7 +110,7 @@ def create_api_keys_group():
                 limits_vcu,
                 limits_usd,
             )
-        except (VeniceAPIError, httpx.RequestError) as e:
+        except (VeniceAPIError, httpx2.RequestError) as e:
             handle_cli_error(e)
         else:
             click.echo(json.dumps(response, indent=2))
@@ -122,7 +122,7 @@ def create_api_keys_group():
         """Delete an API key by ID."""
         try:
             response = api_keys.delete_api_key(ctx.obj["headers"], api_key_id)
-        except (VeniceAPIError, httpx.RequestError) as e:
+        except (VeniceAPIError, httpx2.RequestError) as e:
             handle_cli_error(e)
         else:
             click.echo(json.dumps(response, indent=2))

--- a/llm_venice/cli/characters.py
+++ b/llm_venice/cli/characters.py
@@ -1,7 +1,7 @@
 """Characters command for Venice CLI."""
 
 import click
-import httpx
+import httpx2
 
 from llm_venice.api.characters import list_characters, persist_characters
 from llm_venice.api.errors import VeniceAPIError
@@ -29,7 +29,7 @@ def create_characters_command():
         key = get_venice_key(click_exceptions=True)
         try:
             characters_data = list_characters(key, web_enabled=web_enabled, adult=adult)
-        except (VeniceAPIError, httpx.RequestError) as e:
+        except (VeniceAPIError, httpx2.RequestError) as e:
             handle_cli_error(e)
         path = persist_characters(characters_data)
         characters_count = len(characters_data.get("data", []))

--- a/llm_venice/cli/upscale.py
+++ b/llm_venice/cli/upscale.py
@@ -1,7 +1,7 @@
 """Upscale command for Venice CLI."""
 
 import click
-import httpx
+import httpx2
 import llm
 
 from llm_venice.api.upscale import perform_image_upscale, write_upscaled_image
@@ -74,7 +74,7 @@ def create_upscale_command():
             handle_cli_error(e)
         except ValueError as e:
             handle_cli_error(e)
-        except httpx.RequestError as e:
+        except httpx2.RequestError as e:
             handle_cli_error(e)
         saved_path = write_upscaled_image(result)
         click.echo(f"Upscaled image saved to {saved_path}")

--- a/llm_venice/cli/venice_group.py
+++ b/llm_venice/cli/venice_group.py
@@ -1,7 +1,7 @@
 """Main venice CLI command group."""
 
 import click
-import httpx
+import httpx2
 
 from llm_venice.api.refresh import fetch_models, persist_models
 from llm_venice.api.errors import VeniceAPIError
@@ -31,7 +31,7 @@ def create_venice_group():
         key = get_venice_key(click_exceptions=True)
         try:
             models = fetch_models(key)
-        except (ValueError, VeniceAPIError, httpx.RequestError) as e:
+        except (ValueError, VeniceAPIError, httpx2.RequestError) as e:
             handle_cli_error(e)
         path = persist_models(models)
         click.echo(f"{len(models)} models saved to {path}", err=True)

--- a/llm_venice/models/__init__.py
+++ b/llm_venice/models/__init__.py
@@ -54,6 +54,7 @@ def register_venice_models(register):
                 vision=capabilities.get("supportsVision", False),
                 supports_schema=capabilities.get("supportsResponseSchema", False),
                 supports_tools=capabilities.get("supportsFunctionCalling", False),
+                supports_web_search=supports_web_search,
             )
             async_model_instance = AsyncVeniceChat(
                 model_id=f"venice/{model_id}",
@@ -63,24 +64,22 @@ def register_venice_models(register):
                 vision=capabilities.get("supportsVision", False),
                 supports_schema=capabilities.get("supportsResponseSchema", False),
                 supports_tools=capabilities.get("supportsFunctionCalling", False),
+                supports_web_search=supports_web_search,
             )
-            # Venice-specific capabilities added as instance attributes
-            model_instance.supports_web_search = supports_web_search
-            async_model_instance.supports_web_search = supports_web_search
             register(model_instance, async_model=async_model_instance)
         elif model.get("type") == "image":
             model_instance = VeniceImage(
                 model_id=model_id,
                 model_name=model_id,
                 image_constraints=constraints,
+                supports_web_search=supports_web_search,
             )
             async_model_instance = AsyncVeniceImage(
                 model_id=model_id,
                 model_name=model_id,
                 image_constraints=constraints,
+                supports_web_search=supports_web_search,
             )
-            model_instance.supports_web_search = supports_web_search
-            async_model_instance.supports_web_search = supports_web_search
             register(
                 model_instance,
                 async_model=async_model_instance,

--- a/llm_venice/models/__init__.py
+++ b/llm_venice/models/__init__.py
@@ -2,7 +2,7 @@
 
 import json
 
-import httpx
+import httpx2
 import llm
 
 from llm_venice.models.chat import AsyncVeniceChat, VeniceChat
@@ -31,7 +31,7 @@ def register_venice_models(register):
             return
         try:
             models = fetch_models(key)
-        except (httpx.RequestError, ValueError, VeniceAPIError):
+        except (httpx2.RequestError, ValueError, VeniceAPIError):
             return
         persist_models(models, venice_models_path)
 

--- a/llm_venice/models/audio.py
+++ b/llm_venice/models/audio.py
@@ -9,7 +9,7 @@ import sys
 import time
 from typing import AsyncGenerator, Iterable, Iterator, Literal, Optional, Union
 
-import httpx
+import httpx2
 import llm
 from llm.utils import logging_client
 from pydantic import Field
@@ -285,7 +285,7 @@ def _stream_speech_request(*, api_key: str, payload: dict, headers: dict):
             ) as r:
                 yield r
     else:
-        with httpx.stream(
+        with httpx2.stream(
             "POST",
             ENDPOINT_AUDIO_SPEECH,
             headers=headers,
@@ -332,7 +332,7 @@ def _stream_speech_bytes(
     with _stream_speech_request(api_key=api_key, payload=payload, headers=headers) as r:
         try:
             r.raise_for_status()
-        except httpx.HTTPStatusError as exc:
+        except httpx2.HTTPStatusError as exc:
             raise_api_error("Generating speech", exc)
         yield r.headers.get("Content-Type"), r.iter_bytes()
 
@@ -413,14 +413,14 @@ def _post_speech_bytes(*, api_key: str, payload: dict) -> tuple[bytes, Optional[
             r = client.post(ENDPOINT_AUDIO_SPEECH, headers=headers, json=payload, timeout=120)
             try:
                 r.raise_for_status()
-            except httpx.HTTPStatusError as exc:
+            except httpx2.HTTPStatusError as exc:
                 raise_api_error("Generating speech", exc)
             return r.content, r.headers.get("Content-Type")
 
-    r = httpx.post(ENDPOINT_AUDIO_SPEECH, headers=headers, json=payload, timeout=120)
+    r = httpx2.post(ENDPOINT_AUDIO_SPEECH, headers=headers, json=payload, timeout=120)
     try:
         r.raise_for_status()
-    except httpx.HTTPStatusError as exc:
+    except httpx2.HTTPStatusError as exc:
         raise_api_error("Generating speech", exc)
     return r.content, r.headers.get("Content-Type")
 

--- a/llm_venice/models/chat.py
+++ b/llm_venice/models/chat.py
@@ -181,6 +181,10 @@ class VeniceChat(Chat):
     key_env_var = "LLM_VENICE_KEY"
     supports_web_search = False
 
+    def __init__(self, *args, supports_web_search: bool = False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.supports_web_search = supports_web_search
+
     def __str__(self):  # type: ignore[invalid-argument-type]
         return f"Venice Chat: {self.model_id}"
 
@@ -189,9 +193,7 @@ class VeniceChat(Chat):
 
     def build_kwargs(self, prompt, stream):
         base_kwargs = super().build_kwargs(prompt, stream)
-        return _build_venice_kwargs(
-            self.model_id, getattr(self, "supports_web_search", False), base_kwargs
-        )
+        return _build_venice_kwargs(self.model_id, self.supports_web_search, base_kwargs)
 
 
 class AsyncVeniceChat(AsyncChat):
@@ -201,6 +203,10 @@ class AsyncVeniceChat(AsyncChat):
     key_env_var = "LLM_VENICE_KEY"
     supports_web_search = False
 
+    def __init__(self, *args, supports_web_search: bool = False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.supports_web_search = supports_web_search
+
     def __str__(self):  # type: ignore[invalid-argument-type]
         return f"Venice Chat: {self.model_id}"
 
@@ -209,6 +215,4 @@ class AsyncVeniceChat(AsyncChat):
 
     def build_kwargs(self, prompt, stream):
         base_kwargs = super().build_kwargs(prompt, stream)
-        return _build_venice_kwargs(
-            self.model_id, getattr(self, "supports_web_search", False), base_kwargs
-        )
+        return _build_venice_kwargs(self.model_id, self.supports_web_search, base_kwargs)

--- a/llm_venice/models/chat.py
+++ b/llm_venice/models/chat.py
@@ -13,6 +13,20 @@ from typing import Dict
 class VeniceChatOptions(Chat.Options):
     """Options for Venice chat models."""
 
+    # Explicitly redeclare inherited fields for pyright compatibility
+    temperature: Optional[float] = Field(
+        description=(
+            "What sampling temperature to use, between 0 and 2. Higher values like "
+            "0.8 will make the output more random, while lower values like 0.2 will "
+            "make it more focused and deterministic."
+        ),
+        ge=0,
+        le=2,
+        default=None,
+    )
+    max_tokens: Optional[int] = Field(
+        description="Maximum number of tokens to generate.", default=None
+    )
     # Non-standard generation parameters (top-level in extra_body)
     min_p: Optional[float] = Field(
         description=(

--- a/llm_venice/models/image.py
+++ b/llm_venice/models/image.py
@@ -406,10 +406,13 @@ class VeniceImage(llm.KeyModel):
     key_env_var = "LLM_VENICE_KEY"
     supports_web_search = False
 
-    def __init__(self, model_id, model_name=None, image_constraints=None):
+    def __init__(
+        self, model_id, model_name=None, image_constraints=None, supports_web_search=False
+    ):
         self.model_id = f"venice/{model_id}"
         self.model_name = model_id
         self.image_constraints = image_constraints
+        self.supports_web_search = supports_web_search
 
     def __str__(self):
         return f"Venice Image: {self.model_id}"
@@ -435,7 +438,7 @@ class VeniceImage(llm.KeyModel):
                     model_id=self.model_id,
                     model_name=self.model_name,
                     api_key=api_key,
-                    supports_web_search=getattr(self, "supports_web_search", False),
+                    supports_web_search=self.supports_web_search,
                     image_constraints=self.image_constraints,
                 )
             except ValueError as exc:
@@ -471,10 +474,13 @@ class AsyncVeniceImage(llm.AsyncKeyModel):
     key_env_var = "LLM_VENICE_KEY"
     supports_web_search = False
 
-    def __init__(self, model_id, model_name=None, image_constraints=None):
+    def __init__(
+        self, model_id, model_name=None, image_constraints=None, supports_web_search=False
+    ):
         self.model_id = f"venice/{model_id}"
         self.model_name = model_id
         self.image_constraints = image_constraints
+        self.supports_web_search = supports_web_search
 
     def __str__(self):
         return f"Venice Image: {self.model_id}"
@@ -501,7 +507,7 @@ class AsyncVeniceImage(llm.AsyncKeyModel):
                     model_id=self.model_id,
                     model_name=self.model_name,
                     api_key=api_key,
-                    supports_web_search=getattr(self, "supports_web_search", False),
+                    supports_web_search=self.supports_web_search,
                     image_constraints=self.image_constraints,
                 )
             except ValueError as exc:

--- a/llm_venice/models/image.py
+++ b/llm_venice/models/image.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from dataclasses import field as dataclass_field
 from typing import Any, Literal, Optional, Union
 
-import httpx
+import httpx2
 import llm
 from llm.utils import logging_client
 from pydantic import ConfigDict, Field, model_validator
@@ -123,7 +123,7 @@ class ImageGenerationResult:
     notices: list[VeniceNotice] = dataclass_field(default_factory=list)
 
 
-def _is_true_response_header(headers: httpx.Headers, header_name: str) -> bool:
+def _is_true_response_header(headers: httpx2.Headers, header_name: str) -> bool:
     """Return True when a Venice boolean response header is explicitly enabled."""
     return headers.get(header_name, "").lower() == "true"
 
@@ -287,7 +287,7 @@ def generate_image_result(
             r = client.post(ENDPOINT_IMAGE_GENERATE, headers=headers, json=payload, timeout=120)
             try:
                 r.raise_for_status()
-            except httpx.HTTPStatusError as exc:
+            except httpx2.HTTPStatusError as exc:
                 raise_api_error("Generating image", exc)
 
             content_violation = _is_true_response_header(r.headers, "x-venice-is-content-violation")
@@ -315,11 +315,11 @@ def generate_image_result(
                 }
                 image_bytes_list = _decode_base64_images(data)
     else:
-        r = httpx.post(ENDPOINT_IMAGE_GENERATE, headers=headers, json=payload, timeout=120)
+        r = httpx2.post(ENDPOINT_IMAGE_GENERATE, headers=headers, json=payload, timeout=120)
 
         try:
             r.raise_for_status()
-        except httpx.HTTPStatusError as exc:
+        except httpx2.HTTPStatusError as exc:
             raise_api_error("Generating image", exc)
 
         content_violation = _is_true_response_header(r.headers, "x-venice-is-content-violation")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ indent-width = 4
 target-version = "py310"
 
 [tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,10 @@ include = [
     "tests",
 ]
 exclude = [
+    ".venv",
+    "**/.*",
     "**/__pycache__",
+    "**/node_modules",
 ]
 defineConstant = { DEBUG = true }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License"
 ]
 dependencies = [
-    "llm>=0.28",
+    "httpx2",
+    "llm>=0.33",
 ]
 
 [project.urls]
@@ -24,9 +25,9 @@ venice = "llm_venice"
 
 [project.optional-dependencies]
 test = [
+    "httpx2-pytest>=1.0.1",
     "jsonschema",
     "pytest",
-    "pytest-httpx",
     "sqlite_utils",
 ]
 dev = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Shared fixtures for llm-venice tests"""
 
+import json
 import shutil
 from unittest.mock import patch
 
@@ -42,6 +43,40 @@ def cli_runner():
         CliRunner: A Click test runner configured for isolated testing
     """
     return CliRunner()
+
+
+@pytest.fixture
+def hermetic_venice_model(tmp_path, monkeypatch):
+    """Provide a hermetic Venice model catalog for CLI tests.
+
+    Points LLM_USER_PATH at a temporary directory containing a minimal
+    venice_models.json with a single fake text model, so CLI tests do not
+    depend on the live Venice model catalog (model IDs are deprecated
+    upstream over time, which has repeatedly broken CLI tests).
+
+    Returns:
+        A factory callable: ``hermetic_venice_model(capabilities={...})``
+        writes the catalog and returns the model ID (``venice/test-model``).
+        Calling it with no arguments uses empty capabilities.
+    """
+
+    def make_model(capabilities=None):
+        model_id = "test-model"
+        (tmp_path / "venice_models.json").write_text(
+            json.dumps(
+                [
+                    {
+                        "id": model_id,
+                        "type": "text",
+                        "model_spec": {"capabilities": capabilities or {}},
+                    }
+                ]
+            )
+        )
+        monkeypatch.setenv("LLM_USER_PATH", str(tmp_path))
+        return f"venice/{model_id}"
+
+    return make_model
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_api_keys.py
+++ b/tests/test_api_keys.py
@@ -1,4 +1,4 @@
-import httpx
+import httpx2
 import json
 import pathlib
 
@@ -55,7 +55,7 @@ def test_list_api_keys_http_error(cli_runner, httpx_mock, mock_venice_api_key):
 )
 def test_api_keys_network_error_cli(cli_runner, httpx_mock, mock_venice_api_key, args, method, url):
     """CLI should surface network errors without traceback."""
-    httpx_mock.add_exception(httpx.TimeoutException("Request timed out"), method=method, url=url)
+    httpx_mock.add_exception(httpx2.TimeoutException("Request timed out"), method=method, url=url)
 
     result = cli_runner.invoke(cli, args)
 

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -27,7 +27,7 @@ def test_venice_speech_payload_includes_options(mock_venice_api_key, monkeypatch
     }
     prompt.options = options
 
-    with patch("httpx.post") as mock_post:
+    with patch("httpx2.post") as mock_post:
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None
         mock_response.content = b"fake-audio-bytes"
@@ -56,7 +56,7 @@ def test_venice_speech_payload_includes_options(mock_venice_api_key, monkeypatch
 
 
 def test_venice_speech_streaming_writes_file(mock_venice_api_key, monkeypatch, tmp_path):
-    """stream=True should download audio via httpx.stream and write a file."""
+    """stream=True should download audio via httpx2.stream and write a file."""
     monkeypatch.setenv("LLM_USER_PATH", str(tmp_path))
 
     model = VeniceSpeech("tts-kokoro")
@@ -77,8 +77,8 @@ def test_venice_speech_streaming_writes_file(mock_venice_api_key, monkeypatch, t
     def stream_side_effect(*args, **kwargs):
         return fake_stream(*args, **kwargs)
 
-    with patch("httpx.stream", side_effect=stream_side_effect) as mock_stream:
-        with patch("httpx.post") as mock_post:
+    with patch("httpx2.stream", side_effect=stream_side_effect) as mock_stream:
+        with patch("httpx2.post") as mock_post:
             with patch.object(model, "get_key", return_value=mock_venice_api_key):
                 response = MagicMock()
                 results = list(model.execute(prompt, True, response, None))
@@ -120,8 +120,8 @@ def test_venice_speech_stdout_writes_bytes(mock_venice_api_key, monkeypatch, tmp
 
     dummy_stdout = DummyStdout()
 
-    with patch("httpx.stream", side_effect=lambda *a, **k: fake_stream(*a, **k)) as mock_stream:
-        with patch("httpx.post") as mock_post:
+    with patch("httpx2.stream", side_effect=lambda *a, **k: fake_stream(*a, **k)) as mock_stream:
+        with patch("httpx2.post") as mock_post:
             with patch("sys.stdout", dummy_stdout):
                 with patch.object(model, "get_key", return_value=mock_venice_api_key):
                     response = MagicMock()
@@ -182,8 +182,8 @@ def test_venice_speech_stdout_broken_pipe_still_saves_file(
 
     dummy_stdout = DummyStdout()
 
-    with patch("httpx.stream", side_effect=lambda *a, **k: fake_stream(*a, **k)) as mock_stream:
-        with patch("httpx.post") as mock_post:
+    with patch("httpx2.stream", side_effect=lambda *a, **k: fake_stream(*a, **k)) as mock_stream:
+        with patch("httpx2.post") as mock_post:
             with patch("sys.stdout", dummy_stdout):
                 with patch.object(model, "get_key", return_value=mock_venice_api_key):
                     response = MagicMock()

--- a/tests/test_characters.py
+++ b/tests/test_characters.py
@@ -1,4 +1,4 @@
-import httpx
+import httpx2
 import pytest
 from llm.cli import cli
 
@@ -27,7 +27,7 @@ def test_characters_http_error_cli(cli_runner, httpx_mock, mock_venice_api_key):
 def test_characters_network_error_cli(cli_runner, httpx_mock, mock_venice_api_key):
     """CLI should surface network errors without traceback."""
     httpx_mock.add_exception(
-        httpx.TimeoutException("Request timed out"),
+        httpx2.TimeoutException("Request timed out"),
         method="GET",
         url="https://api.venice.ai/api/v1/characters",
     )

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -171,14 +171,15 @@ def test_venice_chat_options_invalid_values_raise_validation_errors():
 def test_cli_thinking_parameters(cli_runner, monkeypatch, hermetic_venice_model):
     """Test that CLI properly accepts thinking parameters."""
     from llm import cli as llm_cli
-    from unittest.mock import patch, MagicMock
+    from unittest.mock import patch
 
     model_id = hermetic_venice_model()
     monkeypatch.setenv("LLM_VENICE_KEY", "test-venice-key")
-    mock_response = MagicMock()
-    mock_response.text = lambda: "Mock response"
-    mock_response.usage = lambda: (10, 5, 15)
-    with patch.object(VeniceChat, "prompt", return_value=mock_response):
+    with patch.object(
+        VeniceChat,
+        "execute",
+        side_effect=lambda *args, **kwargs: iter(["Mock response"]),
+    ):
         # CLI accepts --strip-thinking-response
         result = cli_runner.invoke(
             llm_cli.cli,
@@ -591,17 +592,16 @@ def test_new_parameters_no_extra_body_pollution():
 
 def test_new_parameters_cli_usage(cli_runner, monkeypatch, hermetic_venice_model):
     """Test that new parameters work via CLI and don't cause runtime errors."""
-    from unittest.mock import patch, MagicMock
+    from unittest.mock import patch
 
     model_id = hermetic_venice_model()
     monkeypatch.setenv("LLM_VENICE_KEY", "test-venice-key")
 
-    # Mock the prompt method to capture what kwargs it receives
-    mock_response = MagicMock()
-    mock_response.text = lambda: "Mock response"
-    mock_response.usage = lambda: (10, 5, 15)
-
-    with patch.object(VeniceChat, "prompt", return_value=mock_response):
+    with patch.object(
+        VeniceChat,
+        "execute",
+        side_effect=lambda *args, **kwargs: iter(["Mock response"]),
+    ):
         from llm import cli as llm_cli
 
         # Test min_p parameter
@@ -966,14 +966,11 @@ def test_cli_web_search_citation_parameters_registration(
 def test_cli_web_search_citation_parameters_usage(cli_runner, monkeypatch, hermetic_venice_model):
     """Test that CLI properly accepts web search citation parameters."""
     from llm import cli as llm_cli
-    from unittest.mock import patch, MagicMock
+    from unittest.mock import patch
 
     # Register the hermetic model with web search support to satisfy validation
     model_id = hermetic_venice_model(capabilities={"supportsWebSearch": True})
     monkeypatch.setenv("LLM_VENICE_KEY", "test-venice-key")
-    mock_response = MagicMock()
-    mock_response.text = lambda: "Mock response with citations"
-    mock_response.usage = lambda: (10, 5, 15)
 
     # Spy on process_venice_options to verify options are forwarded
     from llm_venice.cli import command_hooks
@@ -988,7 +985,11 @@ def test_cli_web_search_citation_parameters_usage(cli_runner, monkeypatch, herme
 
     monkeypatch.setattr(command_hooks, "process_venice_options", spy_process)
 
-    with patch.object(VeniceChat, "prompt", return_value=mock_response):
+    with patch.object(
+        VeniceChat,
+        "execute",
+        side_effect=lambda *args, **kwargs: iter(["Mock response with citations"]),
+    ):
         # Test --web-citations
         result = cli_runner.invoke(
             llm_cli.cli,

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -169,11 +169,12 @@ def test_venice_chat_options_invalid_values_raise_validation_errors():
     assert "enable_web_search must be one of" in str(exc_info.value)
 
 
-def test_cli_thinking_parameters(cli_runner, monkeypatch):
+def test_cli_thinking_parameters(cli_runner, monkeypatch, hermetic_venice_model):
     """Test that CLI properly accepts thinking parameters."""
     from llm import cli as llm_cli
     from unittest.mock import patch, MagicMock
 
+    model_id = hermetic_venice_model()
     monkeypatch.setenv("LLM_VENICE_KEY", "test-venice-key")
     mock_response = MagicMock()
     mock_response.text = lambda: "Mock response"
@@ -185,7 +186,7 @@ def test_cli_thinking_parameters(cli_runner, monkeypatch):
             [
                 "prompt",
                 "-m",
-                "venice/minimax-m25",
+                model_id,
                 "--strip-thinking-response",
                 "--no-log",
                 "Test prompt 1",
@@ -198,7 +199,7 @@ def test_cli_thinking_parameters(cli_runner, monkeypatch):
             [
                 "prompt",
                 "-m",
-                "venice/minimax-m25",
+                model_id,
                 "--disable-thinking",
                 "--no-log",
                 "Test prompt 2",
@@ -211,7 +212,7 @@ def test_cli_thinking_parameters(cli_runner, monkeypatch):
             [
                 "prompt",
                 "-m",
-                "venice/minimax-m25",
+                model_id,
                 "--strip-thinking-response",
                 "--disable-thinking",
                 "--no-log",
@@ -589,10 +590,11 @@ def test_new_parameters_no_extra_body_pollution():
     assert "extra_body" not in kwargs
 
 
-def test_new_parameters_cli_usage(cli_runner, monkeypatch):
+def test_new_parameters_cli_usage(cli_runner, monkeypatch, hermetic_venice_model):
     """Test that new parameters work via CLI and don't cause runtime errors."""
     from unittest.mock import patch, MagicMock
 
+    model_id = hermetic_venice_model()
     monkeypatch.setenv("LLM_VENICE_KEY", "test-venice-key")
 
     # Mock the prompt method to capture what kwargs it receives
@@ -609,7 +611,7 @@ def test_new_parameters_cli_usage(cli_runner, monkeypatch):
             [
                 "prompt",
                 "-m",
-                "venice/venice-uncensored",
+                model_id,
                 "-o",
                 "min_p",
                 "0.05",
@@ -625,7 +627,7 @@ def test_new_parameters_cli_usage(cli_runner, monkeypatch):
             [
                 "prompt",
                 "-m",
-                "venice/venice-uncensored",
+                model_id,
                 "-o",
                 "top_k",
                 "40",
@@ -641,7 +643,7 @@ def test_new_parameters_cli_usage(cli_runner, monkeypatch):
             [
                 "prompt",
                 "-m",
-                "venice/venice-uncensored",
+                model_id,
                 "-o",
                 "repetition_penalty",
                 "1.2",
@@ -657,7 +659,7 @@ def test_new_parameters_cli_usage(cli_runner, monkeypatch):
             [
                 "prompt",
                 "-m",
-                "venice/venice-uncensored",
+                model_id,
                 "-o",
                 "stop_token_ids",
                 "[151643, 151645]",
@@ -673,7 +675,7 @@ def test_new_parameters_cli_usage(cli_runner, monkeypatch):
             [
                 "prompt",
                 "-m",
-                "venice/venice-uncensored",
+                model_id,
                 "-o",
                 "min_p",
                 "0.05",
@@ -931,20 +933,17 @@ def test_cli_web_search_citation_parameters_registration(
     assert "--include-search-results-in-stream" in result.output
 
 
-def test_cli_web_search_citation_parameters_usage(cli_runner, monkeypatch):
+def test_cli_web_search_citation_parameters_usage(cli_runner, monkeypatch, hermetic_venice_model):
     """Test that CLI properly accepts web search citation parameters."""
     from llm import cli as llm_cli
-    import llm
     from unittest.mock import patch, MagicMock
 
+    # Register the hermetic model with web search support to satisfy validation
+    model_id = hermetic_venice_model(capabilities={"supportsWebSearch": True})
     monkeypatch.setenv("LLM_VENICE_KEY", "test-venice-key")
     mock_response = MagicMock()
     mock_response.text = lambda: "Mock response with citations"
     mock_response.usage = lambda: (10, 5, 15)
-
-    # Ensure model supports web search to satisfy validation
-    model = llm.get_model("venice/minimax-m25")
-    model.supports_web_search = True  # type: ignore[invalid-argument-type]
 
     # Spy on process_venice_options to verify options are forwarded
     from llm_venice.cli import command_hooks
@@ -966,7 +965,7 @@ def test_cli_web_search_citation_parameters_usage(cli_runner, monkeypatch):
             [
                 "prompt",
                 "-m",
-                "venice/minimax-m25",
+                model_id,
                 "--web-citations",
                 "--web-search",
                 "on",
@@ -985,7 +984,7 @@ def test_cli_web_search_citation_parameters_usage(cli_runner, monkeypatch):
             [
                 "prompt",
                 "-m",
-                "venice/minimax-m25",
+                model_id,
                 "--web-scraping",
                 "--no-log",
                 "Test with scraping",
@@ -1001,7 +1000,7 @@ def test_cli_web_search_citation_parameters_usage(cli_runner, monkeypatch):
             [
                 "prompt",
                 "-m",
-                "venice/minimax-m25",
+                model_id,
                 "--include-search-results-in-stream",
                 "--web-search",
                 "on",
@@ -1020,7 +1019,7 @@ def test_cli_web_search_citation_parameters_usage(cli_runner, monkeypatch):
             [
                 "prompt",
                 "-m",
-                "venice/minimax-m25",
+                model_id,
                 "--web-citations",
                 "--include-search-results-in-stream",
                 "--web-search",

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -82,20 +82,19 @@ def test_venice_chat_build_kwargs_json_schema():
 
 def test_async_venice_chat_parity_with_sync_build_kwargs():
     """Ensure async Venice chat builds identical kwargs to the sync model."""
+    # Enable web search to exercise Venice-specific validation paths
     sync_chat = VeniceChat(
         model_id="venice/test-model",
         model_name="test-model",
         api_base="https://api.venice.ai/api/v1",
+        supports_web_search=True,
     )
     async_chat = AsyncVeniceChat(
         model_id="venice/test-model",
         model_name="test-model",
         api_base="https://api.venice.ai/api/v1",
+        supports_web_search=True,
     )
-
-    # Enable web search to exercise Venice-specific validation paths
-    sync_chat.supports_web_search = True
-    async_chat.supports_web_search = True
 
     options = VeniceChatOptions(
         min_p=0.05,
@@ -695,6 +694,37 @@ def test_new_parameters_cli_usage(cli_runner, monkeypatch, hermetic_venice_model
         assert result.exit_code == 0, f"Command failed with: {result.output}"
 
 
+def test_cli_web_search_capability_enforced_via_catalog(
+    cli_runner, monkeypatch, hermetic_venice_model
+):
+    """Web search flags must be rejected through the real CLI model-resolution path.
+
+    Regression test: registers the hermetic model WITHOUT web search support and
+    does not mock VeniceChat.prompt, so build_kwargs runs and the capability guard
+    fires. This guards against the dead-code pattern where a capability was set on
+    a throwaway llm.get_model() instance that the CLI never used.
+    """
+    from llm import cli as llm_cli
+
+    model_id = hermetic_venice_model()  # no supportsWebSearch capability
+    monkeypatch.setenv("LLM_VENICE_KEY", "test-venice-key")
+
+    result = cli_runner.invoke(
+        llm_cli.cli,
+        [
+            "prompt",
+            "-m",
+            model_id,
+            "--web-search",
+            "on",
+            "--no-log",
+            "Test prompt",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "does not support web search" in result.output
+
+
 def test_new_parameters_request_shape_client_call(monkeypatch):
     """Spy on the OpenAI client call to ensure request shape is correct.
 
@@ -782,8 +812,8 @@ def test_web_search_capability_guard():
         model_id="venice/test-model",
         model_name="test-model",
         api_base="https://api.venice.ai/api/v1",
+        supports_web_search=False,
     )
-    chat.supports_web_search = False
 
     # Create prompt with web search enabled
     options = VeniceChatOptions(enable_web_search="on")

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -100,8 +100,7 @@ def test_venice_image_aspect_ratio_and_resolution_in_payload(mock_venice_api_key
 
 def test_venice_image_enable_web_search_in_payload(mock_venice_api_key):
     """Test that enable_web_search is included as a top-level image payload field."""
-    model = VeniceImage("test-model")
-    model.supports_web_search = True
+    model = VeniceImage("test-model", supports_web_search=True)
 
     prompt = MagicMock()
     prompt.prompt = "Test prompt"

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, MagicMock, patch, call
 import pytest
 
 import click
-import httpx
+import httpx2
 import llm
 from pydantic import ValidationError
 from click.testing import CliRunner
@@ -38,7 +38,7 @@ def test_venice_image_format_in_payload(mock_venice_api_key):
         prompt.options = options
 
         # Mock the API call
-        with patch("httpx.post") as mock_post:
+        with patch("httpx2.post") as mock_post:
             # Configure the mock response
             mock_response = Mock()
             mock_response.raise_for_status.return_value = None
@@ -82,7 +82,7 @@ def test_venice_image_aspect_ratio_and_resolution_in_payload(mock_venice_api_key
         return_binary=True,
     )
 
-    with patch("httpx.post") as mock_post:
+    with patch("httpx2.post") as mock_post:
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None
         mock_response.headers = {}
@@ -106,7 +106,7 @@ def test_venice_image_enable_web_search_in_payload(mock_venice_api_key):
     prompt.prompt = "Test prompt"
     prompt.options = VeniceImage.Options(enable_web_search=True, return_binary=True)
 
-    with patch("httpx.post") as mock_post:
+    with patch("httpx2.post") as mock_post:
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None
         mock_response.headers = {}
@@ -131,7 +131,7 @@ def test_venice_image_variants_in_payload(mock_venice_api_key):
 
     base64_encoded = base64.b64encode(b"\x89PNG\r\n\x1a\n").decode("utf-8")
 
-    with patch("httpx.post") as mock_post:
+    with patch("httpx2.post") as mock_post:
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None
         mock_response.headers = {}
@@ -162,7 +162,7 @@ def test_venice_image_omits_unset_dimensions_from_payload(mock_venice_api_key):
         return_binary=True,
     )
 
-    with patch("httpx.post") as mock_post:
+    with patch("httpx2.post") as mock_post:
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None
         mock_response.headers = {}
@@ -196,7 +196,7 @@ def test_venice_image_content_violation_handling(mock_venice_api_key):
     prompt.options = options
 
     # Mock the API call with content violation response
-    with patch("httpx.post") as mock_post:
+    with patch("httpx2.post") as mock_post:
         # Configure the mock response with content violation header
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None
@@ -240,7 +240,7 @@ def test_venice_image_blurred_header_exposed_for_json_response(mock_venice_api_k
     raw_binary_content = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"
     base64_encoded = base64.b64encode(raw_binary_content).decode("utf-8")
 
-    with patch("httpx.post") as mock_post:
+    with patch("httpx2.post") as mock_post:
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None
         mock_response.headers = {"x-venice-is-blurred": "true"}
@@ -276,7 +276,7 @@ def test_venice_image_blurred_header_exposed_for_binary_response(mock_venice_api
     prompt.prompt = "Test prompt with adult content"
     prompt.options = VeniceImage.Options(return_binary=True)
 
-    with patch("httpx.post") as mock_post:
+    with patch("httpx2.post") as mock_post:
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None
         mock_response.headers = {"x-venice-is-blurred": "true"}
@@ -312,7 +312,7 @@ def test_venice_image_return_binary_vs_json_parsing(mock_venice_api_key, tmp_pat
     # Test Case 1: return_binary=True - should use raw content
     prompt.options = VeniceImage.Options(return_binary=True)
 
-    with patch("httpx.post") as mock_post:
+    with patch("httpx2.post") as mock_post:
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None
         mock_response.headers = {}
@@ -336,7 +336,7 @@ def test_venice_image_return_binary_vs_json_parsing(mock_venice_api_key, tmp_pat
     # Test Case 2: return_binary=False - should parse JSON and decode base64
     prompt.options = VeniceImage.Options(return_binary=False)
 
-    with patch("httpx.post") as mock_post:
+    with patch("httpx2.post") as mock_post:
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None
         mock_response.headers = {}
@@ -387,7 +387,7 @@ def test_venice_image_variants_save_all_images_and_expose_response_json(
     first_encoded = base64.b64encode(first_image).decode("utf-8")
     second_encoded = base64.b64encode(second_image).decode("utf-8")
 
-    with patch("httpx.post") as mock_post:
+    with patch("httpx2.post") as mock_post:
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None
         mock_response.headers = {}
@@ -431,7 +431,7 @@ def test_venice_image_default_output_directory_creation(mock_venice_api_key, tmp
     }
     prompt.options = options
 
-    with patch("httpx.post") as mock_post:
+    with patch("httpx2.post") as mock_post:
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None
         mock_response.headers = {}
@@ -465,7 +465,7 @@ def test_venice_image_default_filename_path(mock_venice_api_key, tmp_path):
     }
     prompt.options = options
 
-    with patch("httpx.post") as mock_post:
+    with patch("httpx2.post") as mock_post:
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None
         mock_response.headers = {}
@@ -517,7 +517,7 @@ def test_existing_file_no_overwrite_adds_timestamp(mock_venice_api_key, tmp_path
 
     # Mock API response
     new_content = b"\x89PNG\r\n\x1a\nnew image content"
-    with patch("httpx.post") as mock_post:
+    with patch("httpx2.post") as mock_post:
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None
         mock_response.headers = {}
@@ -571,7 +571,7 @@ def test_existing_file_with_overwrite_replaces_file(mock_venice_api_key, tmp_pat
 
     # Mock API response
     new_content = b"\x89PNG\r\n\x1a\nnew overwritten content"
-    with patch("httpx.post") as mock_post:
+    with patch("httpx2.post") as mock_post:
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None
         mock_response.headers = {}
@@ -620,7 +620,7 @@ def test_non_writable_directory_raises_model_error(mock_venice_api_key, tmp_path
     prompt.options = options
 
     # Mock API response
-    with patch("httpx.post") as mock_post:
+    with patch("httpx2.post") as mock_post:
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None
         mock_response.headers = {}
@@ -662,7 +662,7 @@ def test_nonexistent_directory_is_created_when_saving(mock_venice_api_key, tmp_p
     prompt.options = options
 
     # Mock API response
-    with patch("httpx.post") as mock_post:
+    with patch("httpx2.post") as mock_post:
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None
         mock_response.headers = {}
@@ -705,7 +705,7 @@ def test_file_path_instead_of_directory_raises_model_error(mock_venice_api_key, 
     prompt.options = options
 
     # Mock API response
-    with patch("httpx.post") as mock_post:
+    with patch("httpx2.post") as mock_post:
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None
         mock_response.headers = {}
@@ -745,7 +745,7 @@ def test_timestamp_format_in_appended_filename(mock_venice_api_key, tmp_path):
     prompt.options = options
 
     # Mock API response
-    with patch("httpx.post") as mock_post:
+    with patch("httpx2.post") as mock_post:
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None
         mock_response.headers = {}
@@ -797,7 +797,7 @@ def test_no_existing_file_no_timestamp(mock_venice_api_key, tmp_path):
 
     # Mock API response
     content = b"new file content"
-    with patch("httpx.post") as mock_post:
+    with patch("httpx2.post") as mock_post:
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None
         mock_response.headers = {}
@@ -842,7 +842,7 @@ def test_multiple_collisions_create_multiple_timestamped_files(mock_venice_api_k
         }
         prompt.options = options
 
-        with patch("httpx.post") as mock_post:
+        with patch("httpx2.post") as mock_post:
             mock_response = Mock()
             mock_response.raise_for_status.return_value = None
             mock_response.headers = {}
@@ -881,7 +881,7 @@ def test_http_error_raises_model_error(mock_venice_api_key):
     prompt.options = VeniceImage.Options(return_binary=True)
 
     # Mock the API call with HTTP error
-    with patch("httpx.post") as mock_post:
+    with patch("httpx2.post") as mock_post:
         # Configure the mock response to raise HTTPStatusError
         mock_response = Mock()
         mock_response.text = "API Error: Rate limit exceeded"
@@ -890,7 +890,7 @@ def test_http_error_raises_model_error(mock_venice_api_key):
         mock_response.json.side_effect = ValueError
 
         # Create an HTTPStatusError
-        http_error = httpx.HTTPStatusError(
+        http_error = httpx2.HTTPStatusError(
             "429 Client Error",
             request=Mock(),
             response=mock_response,
@@ -923,7 +923,7 @@ def test_invalid_base64_data_raises_model_error(mock_venice_api_key):
 
     # Mock the API call with invalid base64 data - using non-string type
     # which will cause base64.b64decode to raise TypeError
-    with patch("httpx.post") as mock_post:
+    with patch("httpx2.post") as mock_post:
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None
         mock_response.headers = {}
@@ -962,7 +962,7 @@ def test_file_write_failure_raises_model_error(mock_venice_api_key, tmp_path):
     prompt.options = options
 
     # Mock the API call with valid response
-    with patch("httpx.post") as mock_post:
+    with patch("httpx2.post") as mock_post:
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None
         mock_response.headers = {}
@@ -997,14 +997,14 @@ def test_http_500_error_with_json_body(mock_venice_api_key):
     prompt.options = options
 
     # Mock the API call with 500 error
-    with patch("httpx.post") as mock_post:
+    with patch("httpx2.post") as mock_post:
         mock_response = Mock()
         mock_response.text = '{"error": "Internal server error", "code": "server_error"}'
         mock_response.status_code = 500
         mock_response.reason_phrase = "Internal Server Error"
         mock_response.json.return_value = {"error": "Internal server error", "code": "server_error"}
 
-        http_error = httpx.HTTPStatusError(
+        http_error = httpx2.HTTPStatusError(
             "500 Server Error",
             request=Mock(),
             response=mock_response,
@@ -1145,7 +1145,7 @@ def test_venice_image_drops_aspect_ratio_for_unsupported_model(mock_venice_api_k
     prompt.prompt = "Test prompt"
     prompt.options = VeniceImage.Options(aspect_ratio="9:16", return_binary=True)
 
-    with patch("httpx.post") as mock_post:
+    with patch("httpx2.post") as mock_post:
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None
         mock_response.headers = {}
@@ -1175,7 +1175,7 @@ def test_venice_image_drops_resolution_for_unsupported_model(mock_venice_api_key
     prompt.prompt = "Test prompt"
     prompt.options = VeniceImage.Options(resolution="4K", return_binary=True)
 
-    with patch("httpx.post") as mock_post:
+    with patch("httpx2.post") as mock_post:
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None
         mock_response.headers = {}
@@ -1312,7 +1312,7 @@ def test_venice_image_logging_client_usage(mock_venice_api_key, monkeypatch):
     # Set environment variable to enable logging
     monkeypatch.setenv("LLM_VENICE_SHOW_RESPONSES", "1")
 
-    # Mock both httpx.post and logging_client
+    # Mock both httpx2.post and logging_client
     mock_logging_client = Mock()
     mock_client_context = Mock()
     mock_client_instance = Mock()
@@ -1330,7 +1330,7 @@ def test_venice_image_logging_client_usage(mock_venice_api_key, monkeypatch):
     response = MagicMock()
 
     with patch("llm_venice.models.image.logging_client", mock_logging_client):
-        with patch("llm_venice.models.image.httpx.post") as mock_httpx_post:
+        with patch("llm_venice.models.image.httpx2.post") as mock_httpx_post:
             with patch.object(model, "get_key", return_value=mock_venice_api_key):
                 with patch("pathlib.Path.write_bytes"):
                     list(model.execute(prompt, False, response, None))
@@ -1338,11 +1338,11 @@ def test_venice_image_logging_client_usage(mock_venice_api_key, monkeypatch):
                     # Verify logging_client was called
                     mock_logging_client.assert_called_once()
 
-                    # Verify the logging client's post method was called instead of httpx.post
+                    # Verify the logging client's post method was called instead of httpx2.post
                     mock_client_instance.post.assert_called_once()
                     call_args = mock_client_instance.post.call_args
 
-                    # httpx.post should not be used when logging client is enabled
+                    # httpx2.post should not be used when logging client is enabled
                     mock_httpx_post.assert_not_called()
 
                 # Verify the call had the correct parameters
@@ -1374,7 +1374,7 @@ def test_venice_image_honors_explicit_key(monkeypatch):
 
         return FakeResponse()
 
-    monkeypatch.setattr("llm_venice.models.image.httpx.post", fake_post)
+    monkeypatch.setattr("llm_venice.models.image.httpx2.post", fake_post)
 
     with patch.object(model, "get_key", return_value="explicit-key"):
         with patch("pathlib.Path.write_bytes"):

--- a/tests/test_image_upscale.py
+++ b/tests/test_image_upscale.py
@@ -252,25 +252,25 @@ def test_upscale_cli_file_not_found(mock_venice_api_key, cli_runner):
 
 def test_upscale_network_timeout(httpx_mock, temp_image_file, mock_venice_api_key):
     """Test handling of network timeouts"""
-    import httpx
+    import httpx2
 
     # Mock a timeout response
     httpx_mock.add_exception(
-        httpx.TimeoutException("Request timed out"),
+        httpx2.TimeoutException("Request timed out"),
         method="POST",
         url="https://api.venice.ai/api/v1/image/upscale",
     )
 
-    with pytest.raises(httpx.TimeoutException):
+    with pytest.raises(httpx2.TimeoutException):
         perform_image_upscale(str(temp_image_file), scale=2)
 
 
 def test_upscale_network_error_cli(cli_runner, httpx_mock, temp_image_file, mock_venice_api_key):
     """CLI should surface network errors without traceback."""
-    import httpx
+    import httpx2
 
     httpx_mock.add_exception(
-        httpx.TimeoutException("Request timed out"),
+        httpx2.TimeoutException("Request timed out"),
         method="POST",
         url="https://api.venice.ai/api/v1/image/upscale",
     )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,7 +3,6 @@ import json
 import llm
 from llm.cli import cli
 import pytest
-import sqlite_utils
 
 from llm_venice import VeniceChat
 
@@ -26,6 +25,7 @@ def test_prompt_web_search(cli_runner, isolated_llm_dir):
             "--web-search",
             "on",
             "--no-stream",
+            "--json",
             "What is VVV by Venice AI?",
         ],
     )
@@ -37,10 +37,9 @@ def test_prompt_web_search(cli_runner, isolated_llm_dir):
     logs_db_path = llm.user_dir() / "logs.db"
     assert logs_db_path.parent == isolated_llm_dir  # Verify we're using the temp dir
 
-    db = sqlite_utils.Database(logs_db_path)
-    last_response = list(db["responses"].rows)[-1]
-
-    response_json = json.loads(last_response["response_json"])
+    logged_responses = json.loads(result.output)
+    assert len(logged_responses) == 1
+    response_json = logged_responses[0]["response_json"]
     assert "venice_parameters" in response_json
     assert "web_search_citations" in response_json["venice_parameters"]
 

--- a/tests/test_integration_comprehensive.py
+++ b/tests/test_integration_comprehensive.py
@@ -12,7 +12,6 @@ from pathlib import Path
 import llm
 from llm.cli import cli
 import pytest
-import sqlite_utils
 
 from llm_venice import VeniceChat
 
@@ -364,18 +363,16 @@ class TestWebSearch:
                 "--web-search",
                 "on",
                 "--no-stream",
+                "--json",
                 "What is Venice AI VVV token?",
             ],
         )
 
         assert result.exit_code == 0
 
-        # Check for citations in the database
-        logs_db_path = llm.user_dir() / "logs.db"
-        db = sqlite_utils.Database(logs_db_path)
-        last_response = list(db["responses"].rows)[-1]
-
-        response_json = json.loads(last_response["response_json"])
+        logged_responses = json.loads(result.output)
+        assert len(logged_responses) == 1
+        response_json = logged_responses[0]["response_json"]
         assert "venice_parameters" in response_json
         assert "web_search_citations" in response_json["venice_parameters"]
 

--- a/tests/test_model_registration.py
+++ b/tests/test_model_registration.py
@@ -1,6 +1,6 @@
 import json
 
-import httpx
+import httpx2
 import llm
 import pytest
 from llm_venice import AsyncVeniceImage, AsyncVeniceSpeech, VeniceImage, VeniceSpeech
@@ -100,9 +100,9 @@ def test_register_skips_on_request_error_without_cache(monkeypatch, tmp_path):
     monkeypatch.setattr(llm, "get_key", lambda *_, **__: "test-key")
 
     def fetch_failure(_key):
-        raise httpx.RequestError(
+        raise httpx2.RequestError(
             "Network down",
-            request=httpx.Request("GET", "https://api.venice.ai/api/v1/models"),
+            request=httpx2.Request("GET", "https://api.venice.ai/api/v1/models"),
         )
 
     monkeypatch.setattr("llm_venice.models.fetch_models", fetch_failure)

--- a/tests/test_model_registration.py
+++ b/tests/test_model_registration.py
@@ -40,6 +40,45 @@ def test_registers_from_cache_without_key(monkeypatch, tmp_path):
     assert [m.model_id for m in registered_async] == ["venice/minimax-m25"]
 
 
+def test_registers_text_model_web_search_capability(monkeypatch, tmp_path):
+    """Ensure supportsWebSearch from the catalog reaches text model instances."""
+    monkeypatch.setenv("LLM_USER_PATH", str(tmp_path))
+    (tmp_path / "venice_models.json").write_text(
+        json.dumps(
+            [
+                {
+                    "id": "search-model",
+                    "type": "text",
+                    "model_spec": {"capabilities": {"supportsWebSearch": True}},
+                },
+                {
+                    "id": "plain-model",
+                    "type": "text",
+                    "model_spec": {"capabilities": {}},
+                },
+            ]
+        )
+    )
+    monkeypatch.setattr(llm, "get_key", lambda *_, **__: None)
+
+    registered = []
+    registered_async = []
+
+    def register(model, async_model=None, aliases=None):
+        registered.append(model)
+        if async_model:
+            registered_async.append(async_model)
+
+    register_venice_models(register)
+
+    by_id = {m.model_id: m for m in registered}
+    async_by_id = {m.model_id: m for m in registered_async}
+    assert by_id["venice/search-model"].supports_web_search is True
+    assert async_by_id["venice/search-model"].supports_web_search is True
+    assert by_id["venice/plain-model"].supports_web_search is False
+    assert async_by_id["venice/plain-model"].supports_web_search is False
+
+
 def test_register_skips_without_cache_or_key(monkeypatch, tmp_path):
     """Skip registration when cache is missing and no key is available."""
     monkeypatch.setenv("LLM_USER_PATH", str(tmp_path))

--- a/tests/test_refresh.py
+++ b/tests/test_refresh.py
@@ -1,4 +1,4 @@
-import httpx
+import httpx2
 import pytest
 from llm.cli import cli
 
@@ -27,7 +27,7 @@ def test_refresh_http_error_cli(cli_runner, httpx_mock, mock_venice_api_key):
 def test_refresh_network_error_cli(cli_runner, httpx_mock, mock_venice_api_key):
     """CLI should present network errors cleanly when refresh fails."""
     httpx_mock.add_exception(
-        httpx.TimeoutException("Request timed out"),
+        httpx2.TimeoutException("Request timed out"),
         method="GET",
         url="https://api.venice.ai/api/v1/models?type=all",
     )


### PR DESCRIPTION
- Simplify AGENTS.md
- Use a test fixture with model id: decouples tests from live model catalog IDs which can get stale.
- pyproject.toml: Resolve `missingDefaultExcludes` warning.
- Make `supports_web_search` a constructor parameter.
- Redeclare `VeniceChatOptions` inherited fields for pyright compatibility.
- pyproject.toml: tool.ruff.lint: use legacy rules for now with newer ruff versions.
- Update to llm>=0.33, httpx2, httpx2-pytest, and transitively OpenAI 3.
- Tests: Avoid legacy responses table by  using `prompt --json`.